### PR TITLE
Support embedding of inline source strings in NIR:

### DIFF
--- a/nativelib/src/main/scala/scala/scalanative/annotation/InlineSource.scala
+++ b/nativelib/src/main/scala/scala/scalanative/annotation/InlineSource.scala
@@ -1,0 +1,11 @@
+package scala.scalanative.annotation
+
+import scala.annotation.StaticAnnotation
+
+/** Embeds a source string into the NIR representation.
+ *
+ * @param language identifier for the language of the string
+ * @param source string to be embedded into NIR
+ */
+final class InlineSource(language: String, source: String)
+    extends StaticAnnotation

--- a/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Attrs.scala
@@ -30,6 +30,12 @@ object Attr {
   final case object Extern            extends Attr
   final case class Link(name: String) extends Attr
   final case object Abstract          extends Attr
+
+  final case class InlineSource(language: String,
+                                source: String,
+                                annottee: String,
+                                version: Long)
+      extends Attr
 }
 
 final case class Attrs(inline: Inline = MayInline,
@@ -39,7 +45,8 @@ final case class Attrs(inline: Inline = MayInline,
                        isDyn: Boolean = false,
                        isStub: Boolean = false,
                        isAbstract: Boolean = false,
-                       links: Seq[Attr.Link] = Seq()) {
+                       links: Seq[Attr.Link] = Seq(),
+                       extSources: Seq[Attr.InlineSource] = Seq()) {
   def toSeq: Seq[Attr] = {
     val out = mutable.UnrolledBuffer.empty[Attr]
 
@@ -51,6 +58,7 @@ final case class Attrs(inline: Inline = MayInline,
     if (isStub) out += Stub
     if (isAbstract) out += Abstract
     out ++= links
+    out ++= extSources
 
     out
   }
@@ -68,16 +76,18 @@ object Attrs {
     var isAbstract = false
     val overrides  = mutable.UnrolledBuffer.empty[Global]
     val links      = mutable.UnrolledBuffer.empty[Attr.Link]
+    val extSources = mutable.UnrolledBuffer.empty[Attr.InlineSource]
 
     attrs.foreach {
-      case attr: Inline     => inline = attr
-      case attr: Specialize => specialize = attr
-      case attr: Opt        => opt = attr
-      case Extern           => isExtern = true
-      case Dyn              => isDyn = true
-      case Stub             => isStub = true
-      case link: Attr.Link  => links += link
-      case Abstract         => isAbstract = true
+      case attr: Inline            => inline = attr
+      case attr: Specialize        => specialize = attr
+      case attr: Opt               => opt = attr
+      case Extern                  => isExtern = true
+      case Dyn                     => isDyn = true
+      case Stub                    => isStub = true
+      case link: Attr.Link         => links += link
+      case Abstract                => isAbstract = true
+      case extSource: InlineSource => extSources += extSource
     }
 
     new Attrs(inline,
@@ -87,6 +97,7 @@ object Attrs {
               isDyn,
               isStub,
               isAbstract,
-              links)
+              links,
+              extSources)
   }
 }

--- a/nir/src/main/scala/scala/scalanative/nir/Show.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/Show.scala
@@ -107,6 +107,16 @@ object Show {
         str("link(\"")
         str(escapeQuotes(name))
         str("\")")
+      case Attr.InlineSource(lang, src, annottee, version) =>
+        str("inlinesource(\"")
+        str(escapeQuotes(lang))
+        str("\",\"")
+        str(escapeQuotes(src))
+        str("\",\"")
+        str(annottee)
+        str("\",")
+        str(version)
+        str(")")
       case Attr.Abstract =>
         str("abstract")
     }

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinaryDeserializer.scala
@@ -73,6 +73,9 @@ final class BinaryDeserializer(buffer: ByteBuffer) {
     case T.ExternAttr   => Attr.Extern
     case T.LinkAttr     => Attr.Link(getUTF8String)
     case T.AbstractAttr => Attr.Abstract
+
+    case T.InlineSrcAttr =>
+      Attr.InlineSource(getUTF8String, getUTF8String, getUTF8String, getLong)
   }
 
   private def getBin(): Bin = getInt match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/BinarySerializer.scala
@@ -83,6 +83,13 @@ final class BinarySerializer(buffer: ByteBuffer) {
     case Attr.Extern   => putInt(T.ExternAttr)
     case Attr.Link(s)  => putInt(T.LinkAttr); putUTF8tring(s)
     case Attr.Abstract => putInt(T.AbstractAttr)
+
+    case Attr.InlineSource(lang, src, annottee, version) =>
+      putInt(T.InlineSrcAttr)
+      putUTF8tring(lang)
+      putUTF8tring(src)
+      putUTF8tring(annottee)
+      putLong(version)
   }
 
   private def putBin(bin: Bin) = bin match {

--- a/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
+++ b/nir/src/main/scala/scala/scalanative/nir/serialization/Tags.scala
@@ -28,6 +28,7 @@ object Tags {
   final val DynAttr          = 1 + LinkAttr
   final val StubAttr         = 1 + DynAttr
   final val AbstractAttr     = 1 + StubAttr
+  final val InlineSrcAttr    = 1 + AbstractAttr
 
   // Binary ops
 

--- a/nirparser/src/main/scala/scala/scalanative/nir/parser/Attr.scala
+++ b/nirparser/src/main/scala/scala/scalanative/nir/parser/Attr.scala
@@ -23,8 +23,11 @@ object Attr extends Base[nir.Attr] {
   val Extern        = P("extern".! map (_ => nir.Attr.Extern))
   val Link          = P("link(" ~ stringLit ~ ")" map (nir.Attr.Link(_)))
   val Abstract      = P("abstract".! map (_ => nir.Attr.Abstract))
+  val InlineSource = P(
+    "inlinesource(" ~ stringLit ~ "," ~ stringLit ~ "," ~ stringLit ~ "," ~ Long ~ ")" map (
+        p => nir.Attr.InlineSource(p._1, p._2, p._3, p._4)))
 
   override val parser: P[nir.Attr] =
-    MayInline | InlineHint | NoInline | AlwaysInline | MaySpecialize | NoSpecialize | UnOpt | DidOpt | BailOpt | Dyn | Stub | Extern | Link | Abstract
+    MayInline | InlineHint | NoInline | AlwaysInline | MaySpecialize | NoSpecialize | UnOpt | DidOpt | BailOpt | Dyn | Stub | InlineSource | Extern | Link | Abstract
 
 }

--- a/nirparser/src/test/scala/scala/scalanative/nir/AttrParserTest.scala
+++ b/nirparser/src/test/scala/scala/scalanative/nir/AttrParserTest.scala
@@ -26,7 +26,8 @@ class AttrParserTest extends AnyFunSuite {
     Attr.Link("test"),
     Attr.Link("foo bar"),
     Attr.Link("foo \"bar\" baz"),
-    Attr.Abstract
+    Attr.Abstract,
+    Attr.InlineSource("C++", "typedef foo bar;", "foo.Bar", 4321)
   ).foreach { attr =>
     test(s"parse attr `${attr.show}`") {
       val Parsed.Success(result, _) = parser.Attr.parser.parse(attr.show)

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirDefinitions.scala
@@ -31,6 +31,8 @@ trait NirDefinitions { self: NirGlobalAddons =>
       "scala.scalanative.annotation.nooptimize")
     lazy val NoSpecializeClass = getRequiredClass(
       "scala.scalanative.annotation.nospecialize")
+    lazy val InlineSourceClass = getRequiredClass(
+      "scala.scalanative.annotation.InlineSource")
 
     lazy val NativeModule = getRequiredModule(
       "scala.scalanative.unsafe.package")

--- a/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
+++ b/nscplugin/src/main/scala/scala/scalanative/nscplugin/NirGenStat.scala
@@ -206,6 +206,22 @@ trait NirGenStat { self: NirGenPhase =>
           Attr.Link(name)
         case ann if ann.symbol == StubClass =>
           Attr.Stub
+        case ann if ann.symbol == InlineSourceClass =>
+          val lang = ann.argAtIndex(0) match {
+            case Some(Literal(Constant(x: String))) => x
+            case _ =>
+              unsupported(
+                "parameter 'language' of @InlineSource must be a string literal")
+          }
+          val src = ann.argAtIndex(1) match {
+            case Some(Literal(Constant(x: String))) => x
+            case _ =>
+              unsupported(
+                "parameter 'source' of @InlineSource must be a string literal")
+          }
+          val annottee = cd.symbol.fullName
+          val version  = System.currentTimeMillis()
+          Attr.InlineSource(lang, src, annottee, version)
       }
       val abstractAttr =
         if (sym.isAbstract) Seq(Attr.Abstract) else Seq()

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePlugin.scala
@@ -54,6 +54,10 @@ object ScalaNativePlugin extends AutoPlugin {
     val nativeDump =
       taskKey[Boolean](
         "Shall native toolchain dump intermediate NIR to disk during linking?")
+
+    val nativeInlineSourceHooks =
+      taskKey[Seq[build.Config.InlineSourceHook]](
+        "Hooks that are called during linking with all discovered InlineSource() annotations")
   }
 
   @deprecated("use autoImport instead", "0.3.7")

--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -51,7 +51,8 @@ object ScalaNativePluginInternal {
     nativeLTO := nativeConfig.value.lto.name,
     nativeLinkStubs := nativeConfig.value.linkStubs,
     nativeCheck := nativeConfig.value.check,
-    nativeDump := nativeConfig.value.dump
+    nativeDump := nativeConfig.value.dump,
+    nativeInlineSourceHooks := Seq()
   )
 
   lazy val scalaNativeGlobalSettings: Seq[Setting[_]] = Seq(
@@ -131,6 +132,7 @@ object ScalaNativePluginInternal {
           .withWorkdir(cwd)
           .withTargetTriple(nativeTarget.value)
           .withCompilerConfig(nativeConfig.value)
+          .withInlineSourceHooks(nativeInlineSourceHooks.value)
       }
 
       interceptBuildException(Build.build(config, outpath.toPath))

--- a/scripted-tests/run/inline-source/build.sbt
+++ b/scripted-tests/run/inline-source/build.sbt
@@ -1,0 +1,22 @@
+import scalanative.build.Config.InlineSourceHook
+import scala.scalanative.nir.Attr.InlineSource
+import scala.scalanative.build
+import sbt._
+
+enablePlugins(ScalaNativePlugin)
+
+scalaVersion := "2.11.12"
+
+val hook = new InlineSourceHook {
+  val name = "inline-source test"
+
+  def process(srcs: Seq[InlineSource], logger: build.Logger): Option[String] = {
+    srcs foreach { src =>
+      IO.write(new File(src.annottee + "." + src.language), src.source)
+    }
+    None
+  }
+
+}
+
+nativeInlineSourceHooks += hook

--- a/scripted-tests/run/inline-source/src/main/scala/Hello.scala
+++ b/scripted-tests/run/inline-source/src/main/scala/Hello.scala
@@ -1,0 +1,22 @@
+import scalanative.annotation.InlineSource
+
+object Hello {
+  def main(args: Array[String]): Unit = {
+    val f = new Foo
+    f.foo()
+    Bar.bar()
+  }
+}
+
+@InlineSource("c", "foo")
+class Foo {
+  def foo(): Int = 42
+}
+
+@InlineSource("cpp", "bar")
+object Bar {
+  def bar(): Int = 43
+}
+
+@InlineSource("m", "not linked")
+object NotLinked {}

--- a/scripted-tests/run/inline-source/test
+++ b/scripted-tests/run/inline-source/test
@@ -1,0 +1,5 @@
+> nativeLink
+$ pause
+$ exists Foo.c
+$ exists Bar.cpp
+-$ exists NotLinked.m

--- a/tools/src/main/scala/scala/scalanative/build/Build.scala
+++ b/tools/src/main/scala/scala/scalanative/build/Build.scala
@@ -58,6 +58,15 @@ object Build {
     ScalaNative.logLinked(config, linked)
     val optimized = ScalaNative.optimize(config, linked)
 
+    if (config.inlineSourceHooks.nonEmpty) {
+      config.logger.info("Executing hooks for embedded inline sources:")
+      config.inlineSourceHooks.foreach { hook =>
+        config.logger.time("- " + hook.name) {
+          hook.process(optimized.inlineSources, config.logger)
+        } foreach { stats => config.logger.info("    " + stats) }
+      }
+    }
+
     IO.getAll(workdir, "glob:**.ll").foreach(Files.delete)
     ScalaNative.codegen(config, optimized)
     val generated = IO.getAll(workdir, "glob:**.ll")

--- a/tools/src/main/scala/scala/scalanative/linker/Infos.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Infos.scala
@@ -204,7 +204,8 @@ final class Result(val infos: mutable.Map[Global, Info],
                    val links: Seq[Attr.Link],
                    val defns: Seq[Defn],
                    val dynsigs: Seq[Sig],
-                   val dynimpls: Seq[Global]) {
+                   val dynimpls: Seq[Global],
+                   val inlineSources: Seq[Attr.InlineSource]) {
   lazy val ObjectClass       = infos(Rt.Object.name).asInstanceOf[Class]
   lazy val StringClass       = infos(Rt.StringName).asInstanceOf[Class]
   lazy val StringValueField  = infos(Rt.StringValueName).asInstanceOf[Field]

--- a/tools/src/main/scala/scala/scalanative/linker/Reach.scala
+++ b/tools/src/main/scala/scala/scalanative/linker/Reach.scala
@@ -20,6 +20,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
   val dynsigs       = mutable.Set.empty[Sig]
   val dynimpls      = mutable.Set.empty[Global]
 
+  val inlineSources = mutable.UnrolledBuffer.empty[Attr.InlineSource]
+
   entries.foreach(reachEntry)
   loader.classesWithEntryPoints.foreach(reachClinit)
 
@@ -36,7 +38,8 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
                links.toSeq,
                defns,
                dynsigs.toSeq,
-               dynimpls.toSeq)
+               dynimpls.toSeq,
+               inlineSources)
   }
 
   def cleanup(): Unit = {
@@ -433,8 +436,10 @@ class Reach(config: build.Config, entries: Seq[Global], loader: ClassLoader) {
     reachAttrs(attrs)
   }
 
-  def reachAttrs(attrs: Attrs): Unit =
+  def reachAttrs(attrs: Attrs): Unit = {
     links ++= attrs.links
+    inlineSources ++= attrs.extSources
+  }
 
   def reachType(ty: Type): Unit = ty match {
     case Type.ArrayValue(ty, n) =>


### PR DESCRIPTION
- add new annotation InlineSource(source,language)

- add new NIR tag InlineSource

- handle tag in BinarySerializer/BinaryDeserializer

- collect all InlineSource attrs during linking

- add Config.inlineSourceHooks; registered hooks are called with the list of InlineSource attrs after optimization is completed

- provide sbt settingKey nativeInlineSourcesHooks to register hooks that should be called after optimization is completed